### PR TITLE
Add function clause for Rummage.Ecto.Hook.get_module

### DIFF
--- a/lib/rummage_ecto/hook.ex
+++ b/lib/rummage_ecto/hook.ex
@@ -106,4 +106,5 @@ defmodule Rummage.Ecto.Hook do
   def get_module({_, module}) when is_atom(module), do: module
   def get_module(%Ecto.Query{from: _from} = query), do: get_module(query.from)
   def get_module(%Ecto.SubQuery{query: query}), do: get_module(query)
+  def get_module(%Ecto.Query.FromExpr{source: {_, query}}), do: get_module(query)
 end


### PR DESCRIPTION
Got an error on `get_module/1` for passing an `%Ecto.Query.FromExpr{}`:

```
** (FunctionClauseError) no function clause matching in Rummage.Ecto.Hook.get_module/1
        (rummage_ecto) lib/rummage_ecto/hook.ex:105: Rummage.Ecto.Hook.get_module(%Ecto.Query.FromExpr{as: nil, hints: [], prefix: nil, source: {"courses", Course}})
```

This PR adds another function clause to get the module if passed arg is a FromExpr.