### PR TITLE
Fix typos.

### DIFF
--- a/doc_readme.md
+++ b/doc_readme.md
@@ -1,13 +1,13 @@
 # Rummage.Ecto
 
-**If you're looking for full `Phoenix` support, `Rummage.Phoenix` uses `Rumamge.Ecto` and adds `HTML` and `Controller` support
+**If you're looking for full `Phoenix` support, `Rummage.Phoenix` uses `Rummage.Ecto` and adds `HTML` and `Controller` support
 to it. You can check `Rummage.Phoenix` out by clicking [here](https://github.com/aditya7iyengar/rummage_phoenix)**
 
 **Please refer for `CHANGELOG` for version specific changes**
 
 `Rummage.Ecto` is a light weight, but powerful framework that can be used to alter `Ecto` queries with Search, Sort and Paginate operations.
 
-It accomplishes the above operations by using `Hooks`, which are modules that implement `Rumamge.Ecto.Hook` behavior.
+It accomplishes the above operations by using `Hooks`, which are modules that implement `Rummage.Ecto.Hook` behavior.
 Each operation: `Search`, `Sort` and `Paginate` have their hooks defined in `Rummage`. By doing this, `Rummage` is completely
 configurable.
 

--- a/lib/rummage_ecto.ex
+++ b/lib/rummage_ecto.ex
@@ -4,7 +4,7 @@ defmodule Rummage.Ecto do
   queries with Search, Sort and Paginate operations.
 
   It accomplishes the above operations by using `Hooks`, which are modules that
-  implement `Rumamge.Ecto.Hook` behavior. Each operation: Search, Sort and Paginate
+  implement `Rummage.Ecto.Hook` behavior. Each operation: Search, Sort and Paginate
   have their hooks defined in Rummage. By doing this, we have made rummage completely
   configurable. For example, if you don't like one of the implementations of Rummage,
   but like the other two, you can configure Rummage to not use it.

--- a/lib/rummage_ecto/hook.ex
+++ b/lib/rummage_ecto/hook.ex
@@ -72,7 +72,7 @@ defmodule Rummage.Ecto.Hook do
   ```
 
   For a better example, check out `Rummage.Ecto.Hook.Paginate` or any other
-  hooks defined in `Rumamge.Ecto`
+  hooks defined in `Rummage.Ecto`
   """
   defmacro __using__(_opts) do
     quote do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Rummage.Ecto.Mixfile do
       package: package(),
 
       # Docs
-      name: "Rumamge.Ecto",
+      name: "Rummage.Ecto",
       docs: docs(),
     ]
   end


### PR DESCRIPTION
Hi, I noticed a typo in module name on https://hexdocs.pm/rummage_ecto/Rummage.Ecto.html page and decided to fix it :)